### PR TITLE
Add keyboard:configure

### DIFF
--- a/kiwmi/input/keyboard.c
+++ b/kiwmi/input/keyboard.c
@@ -127,11 +127,6 @@ keyboard_create(struct kiwmi_server *server, struct wlr_input_device *device)
     keyboard->server = server;
     keyboard->device = device;
 
-    struct xkb_rule_names rules = {0};
-    struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
-    struct xkb_keymap *keymap =
-        xkb_map_new_from_names(context, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS);
-
     keyboard->modifiers.notify = keyboard_modifiers_notify;
     wl_signal_add(&device->keyboard->events.modifiers, &keyboard->modifiers);
 
@@ -141,6 +136,10 @@ keyboard_create(struct kiwmi_server *server, struct wlr_input_device *device)
     keyboard->device_destroy.notify = keyboard_destroy_notify;
     wl_signal_add(&device->events.destroy, &keyboard->device_destroy);
 
+    struct xkb_rule_names rules = {0};
+    struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+    struct xkb_keymap *keymap =
+        xkb_map_new_from_names(context, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS);
     wlr_keyboard_set_keymap(device->keyboard, keymap);
     xkb_keymap_unref(keymap);
     xkb_context_unref(context);

--- a/kiwmi/luak/kiwmi_keyboard.c
+++ b/kiwmi/luak/kiwmi_keyboard.c
@@ -12,52 +12,59 @@
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_keyboard.h>
 #include <wlr/util/log.h>
+#include <xkbcommon/xkbcommon.h>
 
 #include "input/keyboard.h"
 #include "luak/kiwmi_lua_callback.h"
 
 static int
-l_kiwmi_keyboard_set_keymap(lua_State *L)
+l_kiwmi_keyboard_keymap(lua_State *L)
 {
     struct kiwmi_object *obj =
         *(struct kiwmi_object **)luaL_checkudata(L, 1, "kiwmi_keyboard");
+    luaL_checktype(L, 2, LUA_TTABLE);
+
     if (!obj->valid) {
         return luaL_error(L, "kiwmi_keyboard no longer valid");
     }
+
     struct kiwmi_keyboard *keyboard = obj->object;
+    struct xkb_rule_names settings  = {0};
 
-    if (!lua_istable(L, 2)) {
-        return luaL_error(L, "You have to pass a table as parameter.");
-    }
-
-    struct xkb_rule_names settings = {0};
     lua_getfield(L, 2, "rules");
     if (lua_isstring(L, -1)) {
         settings.rules = luaL_checkstring(L, -1);
     }
+
     lua_getfield(L, 2, "model");
     if (lua_isstring(L, -1)) {
         settings.model = luaL_checkstring(L, -1);
     }
+
     lua_getfield(L, 2, "layout");
     if (lua_isstring(L, -1)) {
         settings.layout = luaL_checkstring(L, -1);
     }
+
     lua_getfield(L, 2, "variant");
     if (lua_isstring(L, -1)) {
         settings.variant = luaL_checkstring(L, -1);
     }
+
     lua_getfield(L, 2, "options");
     if (lua_isstring(L, -1)) {
         settings.options = luaL_checkstring(L, -1);
     }
 
     struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
-    struct xkb_keymap *keymap =
-        xkb_keymap_new_from_names(context, &settings, XKB_KEYMAP_COMPILE_NO_FLAGS);
+    struct xkb_keymap *keymap   = xkb_keymap_new_from_names(
+        context, &settings, XKB_KEYMAP_COMPILE_NO_FLAGS);
+
     wlr_keyboard_set_keymap(keyboard->device->keyboard, keymap);
+
     xkb_keymap_unref(keymap);
     xkb_context_unref(context);
+
     return 0;
 }
 
@@ -105,9 +112,9 @@ l_kiwmi_keyboard_modifiers(lua_State *L)
 }
 
 static const luaL_Reg kiwmi_keyboard_methods[] = {
+    {"keymap", l_kiwmi_keyboard_keymap},
     {"modifiers", l_kiwmi_keyboard_modifiers},
     {"on", luaK_callback_register_dispatch},
-    {"set_keymap", l_kiwmi_keyboard_set_keymap},
     {NULL, NULL},
 };
 

--- a/kiwmi/luak/kiwmi_keyboard.c
+++ b/kiwmi/luak/kiwmi_keyboard.c
@@ -17,6 +17,29 @@
 #include "luak/kiwmi_lua_callback.h"
 
 static int
+l_kiwmi_keyboard_configure(lua_State *L)
+{
+    struct kiwmi_keyboard *keyboard =
+        *(struct kiwmi_keyboard **)luaL_checkudata(L, 1, "kiwmi_keyboard");
+
+    struct xkb_rule_names rules = {
+        .rules   = luaL_checkstring(L, 2),
+        .model   = luaL_checkstring(L, 3),
+        .layout  = luaL_checkstring(L, 4),
+        .variant = luaL_checkstring(L, 5),
+        .options = luaL_checkstring(L, 6),
+    };
+    wlr_log(WLR_INFO, " %s ", lua_tostring(L, 2));
+    struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+    struct xkb_keymap *keymap =
+        xkb_map_new_from_names(context, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS);
+    wlr_keyboard_set_keymap(keyboard->device->keyboard, keymap);
+    xkb_keymap_unref(keymap);
+    xkb_context_unref(context);
+    return 0;
+}
+
+static int
 l_kiwmi_keyboard_modifiers(lua_State *L)
 {
     struct kiwmi_object *obj =
@@ -61,6 +84,7 @@ l_kiwmi_keyboard_modifiers(lua_State *L)
 
 static const luaL_Reg kiwmi_keyboard_methods[] = {
     {"modifiers", l_kiwmi_keyboard_modifiers},
+    {"configure", l_kiwmi_keyboard_configure},
     {"on", luaK_callback_register_dispatch},
     {NULL, NULL},
 };

--- a/lua_docs.md
+++ b/lua_docs.md
@@ -121,6 +121,11 @@ These are: `shift`, `caps`, `ctrl`, `alt`, `mod2`, `mod3`, `super`, and `mod5`.
 
 Used to register event listeners.
 
+#### keyboard:configure(rules, model, layout, variant, options)
+
+The parameters are all strings for more information see xkbcommon library.
+<https://xkbcommon.org/doc/current/index.html>
+
 ### Events
 
 #### destroy

--- a/lua_docs.md
+++ b/lua_docs.md
@@ -121,10 +121,13 @@ These are: `shift`, `caps`, `ctrl`, `alt`, `mod2`, `mod3`, `super`, and `mod5`.
 
 Used to register event listeners.
 
-#### keyboard:configure(rules, model, layout, variant, options)
+#### keyboard:set_keymap({})
 
-The parameters are all strings for more information see xkbcommon library.
-<https://xkbcommon.org/doc/current/index.html>
+The funtcion takes a table as parameter.
+The possible table indexes are "rules, model, layout, variant, options".
+All the table parameters are optional and set to the system default if not set.
+For the values to set have a look at the xkbcommon library.
+<https://xkbcommon.org/doc/current/structxkb__rule__names.html>
 
 ### Events
 

--- a/lua_docs.md
+++ b/lua_docs.md
@@ -112,6 +112,14 @@ A handle to a keyboard.
 
 ### Methods
 
+#### keyboard:keymap(keymap)
+
+The funtcion takes a table as parameter.
+The possible table indexes are "rules, model, layout, variant, options".
+All the table parameters are optional and set to the system default if not set.
+For the values to set have a look at the xkbcommon library.
+<https://xkbcommon.org/doc/current/structxkb__rule__names.html>
+
 #### keyboard:modifiers()
 
 Returns a table with the state of all modifiers.
@@ -120,14 +128,6 @@ These are: `shift`, `caps`, `ctrl`, `alt`, `mod2`, `mod3`, `super`, and `mod5`.
 #### keyboard:on(event, callback)
 
 Used to register event listeners.
-
-#### keyboard:set_keymap({})
-
-The funtcion takes a table as parameter.
-The possible table indexes are "rules, model, layout, variant, options".
-All the table parameters are optional and set to the system default if not set.
-For the values to set have a look at the xkbcommon library.
-<https://xkbcommon.org/doc/current/structxkb__rule__names.html>
 
 ### Events
 


### PR DESCRIPTION
Hi, 
I am not complete sure if this is the best way of introducing the ability to set a different keyboard layout and stuff.

This enables the user to set the keyboard configuration as with libxkbcommon.

Site note: the change in input/keyboard.c moves only the lines which should be more clean to put related things together and not some other stuff inbetween. 