### PR TITLE
Fix: Return view's app_id when asked for app_id

### DIFF
--- a/kiwmi/desktop/xdg_shell.c
+++ b/kiwmi/desktop/xdg_shell.c
@@ -145,7 +145,7 @@ xdg_shell_view_get_string_prop(
 {
     switch (prop) {
     case KIWMI_VIEW_PROP_APP_ID:
-        return view->xdg_surface->toplevel->title;
+        return view->xdg_surface->toplevel->app_id;
     case KIWMI_VIEW_PROP_TITLE:
         return view->xdg_surface->toplevel->title;
     default:


### PR DESCRIPTION
(instead of its title)