### PR TITLE
[output render] Assign to variables before they are used by wlroots

### DIFF
--- a/kiwmi/desktop/output.c
+++ b/kiwmi/desktop/output.c
@@ -130,8 +130,8 @@ output_frame_notify(struct wl_listener *listener, void *data)
     wlr_renderer_begin(renderer, width, height);
     wlr_renderer_clear(renderer, (float[]){0.1f, 0.1f, 0.1f, 1.0f});
 
-    double output_lx;
-    double output_ly;
+    double output_lx = 0;
+    double output_ly = 0;
     wlr_output_layout_output_coords(
         output_layout, wlr_output, &output_lx, &output_ly);
 


### PR DESCRIPTION
The `wlr_output_layout_output_coords` function uses the value of all its arguments, so they should have a value assigned before use.

This fixes #21.