### PR TITLE
Add clipboard (& other stuff) support

### DIFF
--- a/include/input/seat.h
+++ b/include/input/seat.h
@@ -23,6 +23,8 @@ struct kiwmi_seat {
     struct kiwmi_layer *focused_layer;
 
     struct wl_listener request_set_cursor;
+    struct wl_listener request_set_selection;
+    struct wl_listener request_set_primary_selection;
 };
 
 void

--- a/kiwmi/server.c
+++ b/kiwmi/server.c
@@ -16,6 +16,7 @@
 #include <wlr/backend.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_data_control_v1.h>
+#include <wlr/types/wlr_gamma_control_v1.h>
 #include <wlr/types/wlr_primary_selection_v1.h>
 #include <wlr/types/wlr_screencopy_v1.h>
 #include <wlr/util/log.h>
@@ -58,6 +59,7 @@ server_init(struct kiwmi_server *server, char *config_path)
     }
 
     wlr_data_control_manager_v1_create(server->wl_display);
+    wlr_gamma_control_manager_v1_create(server->wl_display);
     wlr_primary_selection_v1_device_manager_create(server->wl_display);
 
     server->socket = wl_display_add_socket_auto(server->wl_display);

--- a/kiwmi/server.c
+++ b/kiwmi/server.c
@@ -15,6 +15,8 @@
 #include <wayland-server.h>
 #include <wlr/backend.h>
 #include <wlr/render/wlr_renderer.h>
+#include <wlr/types/wlr_data_control_v1.h>
+#include <wlr/types/wlr_primary_selection_v1.h>
 #include <wlr/types/wlr_screencopy_v1.h>
 #include <wlr/util/log.h>
 
@@ -54,6 +56,9 @@ server_init(struct kiwmi_server *server, char *config_path)
         wl_display_destroy(server->wl_display);
         return false;
     }
+
+    wlr_data_control_manager_v1_create(server->wl_display);
+    wlr_primary_selection_v1_device_manager_create(server->wl_display);
 
     server->socket = wl_display_add_socket_auto(server->wl_display);
     if (!server->socket) {


### PR DESCRIPTION
Closes #26.

I will look into the other stuff (except gamma which is already here) later, I hope it will be this week.

---

The clipboard seems to work only partly, but AFAICT Sway (1.6.1) behaves the same:

Working testcase:

1. open two neovims (in two separate terminals)
2. write something in one
3. (still in the 1st nvim) enter visual mode, select some text, `"+y` (copy into clipboard)
4. switch to the other nvim
5. `"+p` (paste from clipboard) (works)

Failing testcase (if you use primary selection = `"*y` & middle click, it doesn’t fail)

1. open a neovim and a terminal (alacritty, zsh)
2. write something in the nvim, copy it into clipboard
3. switch to the other terminal
4. shift-insert (doesn’t work)