### PR TITLE
kiwmi_view:raise() and :lower()

### DIFF
--- a/include/desktop/desktop.h
+++ b/include/desktop/desktop.h
@@ -11,6 +11,8 @@
 #include <wayland-server.h>
 #include <wlr/render/wlr_renderer.h>
 
+#include "desktop/view.h"
+
 struct kiwmi_desktop {
     struct wlr_compositor *compositor;
     struct wlr_xdg_shell *xdg_shell;
@@ -33,6 +35,10 @@ struct kiwmi_desktop {
     } events;
 };
 
+void desktop_raise_view(
+    struct kiwmi_desktop *desktop,
+    struct kiwmi_view *view,
+    bool raise);
 bool desktop_init(struct kiwmi_desktop *desktop, struct wlr_renderer *renderer);
 void desktop_fini(struct kiwmi_desktop *desktop);
 

--- a/kiwmi/desktop/desktop.c
+++ b/kiwmi/desktop/desktop.c
@@ -29,6 +29,20 @@
 #include "input/input.h"
 #include "server.h"
 
+void
+desktop_raise_view(
+    struct kiwmi_desktop *desktop,
+    struct kiwmi_view *view,
+    bool raise)
+{
+    wl_list_remove(&view->link);
+    if (raise) {
+        wl_list_insert(&desktop->views, &view->link);
+    } else {
+        wl_list_insert(desktop->views.prev, &view->link);
+    }
+}
+
 bool
 desktop_init(struct kiwmi_desktop *desktop, struct wlr_renderer *renderer)
 {

--- a/kiwmi/input/seat.c
+++ b/kiwmi/input/seat.c
@@ -74,15 +74,9 @@ seat_focus_view(struct kiwmi_seat *seat, struct kiwmi_view *view)
         return;
     }
 
-    struct kiwmi_desktop *desktop = view->desktop;
-
     if (seat->focused_view) {
         view_set_activated(seat->focused_view, false);
     }
-
-    // move view to front
-    wl_list_remove(&view->link);
-    wl_list_insert(&desktop->views, &view->link);
 
     seat->focused_view = view;
     view_set_activated(view, true);

--- a/kiwmi/luak/kiwmi_view.c
+++ b/kiwmi/luak/kiwmi_view.c
@@ -208,6 +208,24 @@ l_kiwmi_view_iresize(lua_State *L)
 }
 
 static int
+l_kiwmi_view_lower(lua_State *L)
+{
+    struct kiwmi_object *obj =
+        *(struct kiwmi_object **)luaL_checkudata(L, 1, "kiwmi_view");
+
+    if (!obj->valid) {
+        return luaL_error(L, "kiwmi_view no longer valid");
+    }
+
+    struct kiwmi_view *view       = obj->object;
+    struct kiwmi_desktop *desktop = view->desktop;
+
+    desktop_raise_view(desktop, view, false);
+
+    return 0;
+}
+
+static int
 l_kiwmi_view_move(lua_State *L)
 {
     struct kiwmi_object *obj =
@@ -261,6 +279,24 @@ l_kiwmi_view_pos(lua_State *L)
     lua_pushinteger(L, view->y);
 
     return 2;
+}
+
+static int
+l_kiwmi_view_raise(lua_State *L)
+{
+    struct kiwmi_object *obj =
+        *(struct kiwmi_object **)luaL_checkudata(L, 1, "kiwmi_view");
+
+    if (!obj->valid) {
+        return luaL_error(L, "kiwmi_view no longer valid");
+    }
+
+    struct kiwmi_view *view       = obj->object;
+    struct kiwmi_desktop *desktop = view->desktop;
+
+    desktop_raise_view(desktop, view, true);
+
+    return 0;
 }
 
 static int
@@ -413,10 +449,12 @@ static const luaL_Reg kiwmi_view_methods[] = {
     {"hide", l_kiwmi_view_hide},
     {"imove", l_kiwmi_view_imove},
     {"iresize", l_kiwmi_view_iresize},
+    {"lower", l_kiwmi_view_lower},
     {"move", l_kiwmi_view_move},
     {"on", luaK_callback_register_dispatch},
     {"pid", l_kiwmi_view_pid},
     {"pos", l_kiwmi_view_pos},
+    {"raise", l_kiwmi_view_raise},
     {"resize", l_kiwmi_view_resize},
     {"show", l_kiwmi_view_show},
     {"size", l_kiwmi_view_size},

--- a/lua_docs.md
+++ b/lua_docs.md
@@ -288,6 +288,10 @@ Starts an interactive move.
 Starts an interactive resize.
 Takes a table containing the edges, that the resize is happening on.
 
+#### view:lower()
+
+Moves the view to background.
+
 #### view:move(lx, ly)
 
 Moves the view to the specified position.
@@ -303,6 +307,10 @@ Returns the process ID of the client associated with the view.
 #### view:pos()
 
 Returns the position of the view (top-left corner).
+
+#### view:raise()
+
+Moves the view to foreground.
 
 #### view:resize(width, height)
 


### PR DESCRIPTION
This PR disables auto-raising views on focus; `view:focus()` could get an optional argument defaulting to true.

It doesn’t solve `desktop_active_output` possibly returning a wrong output. It would mean messing with the code around to get access to the seat, so I haven’t done it yet. I can do it if desired.

(this is another PR from `tiosgz/mine`, commit 48439b31cd3746c1026f12a1dca9fbec7ab6071b)