### PR TITLE
Do not add output position twice when rendering

### DIFF
--- a/kiwmi/desktop/output.c
+++ b/kiwmi/desktop/output.c
@@ -39,8 +39,8 @@ render_layer_surface(struct wlr_surface *surface, int x, int y, void *data)
         return;
     }
 
-    int ox = rdata->output_lx + x + geom->x;
-    int oy = rdata->output_ly + y + geom->y;
+    int ox = x + geom->x;
+    int oy = y + geom->y;
 
     struct wlr_box box = {
         .x      = ox * output->scale,


### PR DESCRIPTION
The renderer already uses output-local positions so adding the output position again caused the layer shell surface to be off-screen sometimes.

(this is another PR from `tiosgz/mine`, commit 51c67d3975aec36b8dae9d0fd480b47b9a825aa2)