### PR TITLE
Add controls for verbosity level

### DIFF
--- a/kiwmi/luak/kiwmi_server.c
+++ b/kiwmi/luak/kiwmi_server.c
@@ -192,6 +192,25 @@ l_kiwmi_server_schedule(lua_State *L)
 }
 
 static int
+l_kiwmi_server_set_verbosity(lua_State *L)
+{
+    luaL_checkudata(L, 1, "kiwmi_server");
+    luaL_checktype(L, 2, LUA_TNUMBER);
+
+    int verbosity = lua_tointeger(L, 2);
+
+    if (verbosity < WLR_SILENT) {
+        verbosity = WLR_SILENT;
+    } else if (verbosity >= WLR_LOG_IMPORTANCE_LAST) {
+        verbosity = WLR_DEBUG;
+    }
+
+    wlr_log_init((enum wlr_log_importance)verbosity, NULL);
+
+    return 0;
+}
+
+static int
 l_kiwmi_server_spawn(lua_State *L)
 {
     luaL_checkudata(L, 1, "kiwmi_server");
@@ -242,6 +261,18 @@ l_kiwmi_server_unfocus(lua_State *L)
 }
 
 static int
+l_kiwmi_server_verbosity(lua_State *L)
+{
+    luaL_checkudata(L, 1, "kiwmi_server");
+
+    int verbosity = (int)wlr_log_get_verbosity();
+
+    lua_pushinteger(L, verbosity);
+
+    return 1;
+}
+
+static int
 l_kiwmi_server_view_at(lua_State *L)
 {
     struct kiwmi_object *obj =
@@ -284,9 +315,11 @@ static const luaL_Reg kiwmi_server_methods[] = {
     {"output_at", l_kiwmi_server_output_at},
     {"quit", l_kiwmi_server_quit},
     {"schedule", l_kiwmi_server_schedule},
+    {"set_verbosity", l_kiwmi_server_set_verbosity},
     {"spawn", l_kiwmi_server_spawn},
     {"stop_interactive", l_kiwmi_server_stop_interactive},
     {"unfocus", l_kiwmi_server_unfocus},
+    {"verbosity", l_kiwmi_server_verbosity},
     {"view_at", l_kiwmi_server_view_at},
     {NULL, NULL},
 };

--- a/lua_docs.md
+++ b/lua_docs.md
@@ -50,6 +50,10 @@ Quit kiwmi.
 Call `callback` after `delay` ms.
 Callback get passed itself, so that it can easily reregister itself.
 
+#### kiwmi:set_verbosity(level)
+
+Sets verbosity of kiwmi to the level specified with a number (see `kiwmi:verbosity()`).
+
 #### kiwmi:spawn(command)
 
 Spawn a new process.
@@ -62,6 +66,10 @@ Stops an interactive move or resize.
 #### kiwmi:unfocus()
 
 Unfocus the currently focused view.
+
+#### kiwmi:verbosity()
+
+Returns the numerical verbosity level of kiwmi (value of one of `wlr_log_importance`, silent = 0, error = 1, info = 2, debug = 3).
 
 #### kiwmi:view_at(lx, ly)
 


### PR DESCRIPTION
This allows the config to be exactly as verbose as kiwmi, or to change the verbosity level at runtime (e.g. using `kiwmic`).

It uses numbers, because they are much easier to handle on both sides and add only little inconvenience to the user.

(originally c60e7d4adae1783ba68fe59d621e0d82238a7c34 somewhere in the rainforest near `tiosgz/mine`)