### PR TITLE
kiwmi:bg_color()

### DIFF
--- a/include/color.h
+++ b/include/color.h
@@ -1,0 +1,15 @@
+/* Copyright (c), Niclas Meyer <niclas@countingsort.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef KIWMI_COLOR_H
+#define KIWMI_COLOR_H
+
+#include <stdbool.h>
+
+bool color_parse(const char *hex, float color[static 4]);
+
+#endif /* KIWMI_COLOR_H */

--- a/include/desktop/desktop.h
+++ b/include/desktop/desktop.h
@@ -21,6 +21,8 @@ struct kiwmi_desktop {
     struct wl_list outputs; // struct kiwmi_output::link
     struct wl_list views;   // struct kiwmi_view::link
 
+    float bg_color[4];
+
     struct wl_listener xdg_shell_new_surface;
     struct wl_listener xdg_toplevel_new_decoration;
     struct wl_listener layer_shell_new_surface;

--- a/kiwmi/color.c
+++ b/kiwmi/color.c
@@ -1,0 +1,42 @@
+/* Copyright (c), Niclas Meyer <niclas@countingsort.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "color.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+bool
+color_parse(const char *hex, float color[static 4])
+{
+    if (hex[0] == '#') {
+        ++hex;
+    }
+
+    int len = strlen(hex);
+    if (len != 6 && len != 8) {
+        return false;
+    }
+
+    uint32_t rgba = (uint32_t)strtoul(hex, NULL, 16);
+    if (len == 6) {
+        rgba = (rgba << 8) | 0xff;
+    }
+
+    for (size_t i = 0; i < 4; ++i) {
+        color[3 - i] = (rgba & 0xff) / 255.0;
+        rgba >>= 8;
+    }
+
+    // premultiply alpha
+    color[0] *= color[3];
+    color[1] *= color[3];
+    color[2] *= color[3];
+
+    return true;
+}

--- a/kiwmi/desktop/desktop.c
+++ b/kiwmi/desktop/desktop.c
@@ -43,6 +43,11 @@ desktop_init(struct kiwmi_desktop *desktop, struct wlr_renderer *renderer)
     wlr_xdg_output_manager_v1_create(
         server->wl_display, desktop->output_layout);
 
+    desktop->bg_color[0] = 0.1f;
+    desktop->bg_color[1] = 0.1f;
+    desktop->bg_color[2] = 0.1f;
+    desktop->bg_color[3] = 1.0f;
+
     desktop->xdg_shell = wlr_xdg_shell_create(server->wl_display);
     desktop->xdg_shell_new_surface.notify = xdg_shell_new_surface_notify;
     wl_signal_add(

--- a/kiwmi/desktop/output.c
+++ b/kiwmi/desktop/output.c
@@ -128,7 +128,7 @@ output_frame_notify(struct wl_listener *listener, void *data)
     wlr_output_effective_resolution(wlr_output, &width, &height);
 
     wlr_renderer_begin(renderer, width, height);
-    wlr_renderer_clear(renderer, (float[]){0.1f, 0.1f, 0.1f, 1.0f});
+    wlr_renderer_clear(renderer, desktop->bg_color);
 
     double output_lx = 0;
     double output_ly = 0;

--- a/kiwmi/luak/kiwmi_renderer.c
+++ b/kiwmi/luak/kiwmi_renderer.c
@@ -15,6 +15,7 @@
 #include <wlr/types/wlr_output.h>
 #include <wlr/util/log.h>
 
+#include "color.h"
 #include "desktop/output.h"
 #include "luak/lua_compat.h"
 #include "luak/luak.h"
@@ -23,36 +24,6 @@ struct kiwmi_renderer {
     struct wlr_renderer *wlr_renderer;
     struct kiwmi_output *output;
 };
-
-static bool
-parse_color(const char *hex, float color[static 4])
-{
-    if (hex[0] == '#') {
-        ++hex;
-    }
-
-    int len = strlen(hex);
-    if (len != 6 && len != 8) {
-        return false;
-    }
-
-    uint32_t rgba = (uint32_t)strtoul(hex, NULL, 16);
-    if (len == 6) {
-        rgba = (rgba << 8) | 0xff;
-    }
-
-    for (size_t i = 0; i < 4; ++i) {
-        color[3 - i] = (rgba & 0xff) / 255.0;
-        rgba >>= 8;
-    }
-
-    // premultiply alpha
-    color[0] *= color[3];
-    color[1] *= color[3];
-    color[2] *= color[3];
-
-    return true;
-}
 
 static int
 l_kiwmi_renderer_draw_rect(lua_State *L)
@@ -70,7 +41,7 @@ l_kiwmi_renderer_draw_rect(lua_State *L)
     struct wlr_output *wlr_output     = output->wlr_output;
 
     float color[4];
-    if (!parse_color(lua_tostring(L, 2), color)) {
+    if (!color_parse(lua_tostring(L, 2), color)) {
         return luaL_argerror(L, 2, "not a valid color");
     }
 

--- a/kiwmi/luak/kiwmi_server.c
+++ b/kiwmi/luak/kiwmi_server.c
@@ -17,6 +17,7 @@
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/util/log.h>
 
+#include "color.h"
 #include "desktop/view.h"
 #include "input/cursor.h"
 #include "input/input.h"
@@ -48,6 +49,28 @@ l_kiwmi_server_active_output(lua_State *L)
     }
 
     return 1;
+}
+
+static int
+l_kiwmi_server_bg_color(lua_State *L)
+{
+    struct kiwmi_object *obj =
+        *(struct kiwmi_object **)luaL_checkudata(L, 1, "kiwmi_server");
+    luaL_checktype(L, 2, LUA_TSTRING);
+
+    struct kiwmi_server *server = obj->object;
+
+    float color[4];
+    if (!color_parse(lua_tostring(L, 2), color)) {
+        return luaL_argerror(L, 2, "not a valid color");
+    }
+
+    server->desktop.bg_color[0] = color[0];
+    server->desktop.bg_color[1] = color[1];
+    server->desktop.bg_color[2] = color[2];
+    // ignore alpha
+
+    return 0;
 }
 
 static int
@@ -278,6 +301,7 @@ l_kiwmi_server_view_at(lua_State *L)
 
 static const luaL_Reg kiwmi_server_methods[] = {
     {"active_output", l_kiwmi_server_active_output},
+    {"bg_color", l_kiwmi_server_bg_color},
     {"cursor", l_kiwmi_server_cursor},
     {"focused_view", l_kiwmi_server_focused_view},
     {"on", luaK_callback_register_dispatch},

--- a/kiwmi/meson.build
+++ b/kiwmi/meson.build
@@ -1,6 +1,7 @@
 kiwmi_sources = files(
   'main.c',
   'server.c',
+  'color.c',
   'desktop/desktop.c',
   'desktop/layer_shell.c',
   'desktop/output.c',

--- a/lua_docs.md
+++ b/lua_docs.md
@@ -45,6 +45,10 @@ Used to register event listeners.
 
 Quit kiwmi.
 
+#### kiwmi:bg_color(color)
+
+Sets the background color (shown behind all views) to `color` (in the format #rrggbb).
+
 #### kiwmi:schedule(delay, callback)
 
 Call `callback` after `delay` ms.


### PR DESCRIPTION
There is also an option to call it `bg_paint()` instead, which would (IMO) be generic enough to allow anything static.

(originally e732c48f51ff2c532378f0a568d3e51d10809265 on `tiosgz/mine`)