### PR TITLE
Pointer focus improvements

### DIFF
--- a/include/input/cursor.h
+++ b/include/input/cursor.h
@@ -67,6 +67,12 @@ struct kiwmi_cursor_scroll_event {
     bool handled;
 };
 
+void cursor_refresh_focus(
+    struct kiwmi_cursor *cursor,
+    struct wlr_surface **new_surface,
+    double *cursor_sx,
+    double *cursor_sy);
+
 struct kiwmi_cursor *cursor_create(
     struct kiwmi_server *server,
     struct wlr_output_layout *output_layout);

--- a/kiwmi/desktop/view.c
+++ b/kiwmi/desktop/view.c
@@ -113,8 +113,13 @@ view_set_pos(struct kiwmi_view *view, uint32_t x, uint32_t y)
         }
     }
 
+    struct kiwmi_desktop *desktop = view->desktop;
+    struct kiwmi_server *server   = wl_container_of(desktop, server, desktop);
+    struct kiwmi_cursor *cursor   = server->input.cursor;
+    cursor_refresh_focus(cursor, NULL, NULL, NULL);
+
     struct kiwmi_output *output;
-    wl_list_for_each (output, &view->desktop->outputs, link) {
+    wl_list_for_each (output, &desktop->outputs, link) {
         output_damage(output);
     }
 }

--- a/kiwmi/desktop/xdg_shell.c
+++ b/kiwmi/desktop/xdg_shell.c
@@ -19,6 +19,7 @@
 #include "desktop/desktop.h"
 #include "desktop/output.h"
 #include "desktop/view.h"
+#include "input/cursor.h"
 #include "input/input.h"
 #include "input/seat.h"
 #include "server.h"
@@ -204,9 +205,14 @@ xdg_surface_commit_notify(struct wl_listener *listener, void *UNUSED(data))
 {
     struct kiwmi_view *view = wl_container_of(listener, view, commit);
 
+    struct kiwmi_desktop *desktop = view->desktop;
+    struct kiwmi_server *server   = wl_container_of(desktop, server, desktop);
+    struct kiwmi_cursor *cursor   = server->input.cursor;
+    cursor_refresh_focus(cursor, NULL, NULL, NULL);
+
     if (pixman_region32_not_empty(&view->wlr_surface->buffer_damage)) {
         struct kiwmi_output *output;
-        wl_list_for_each (output, &view->desktop->outputs, link) {
+        wl_list_for_each (output, &desktop->outputs, link) {
             output_damage(output);
         }
     }
@@ -225,6 +231,7 @@ xdg_surface_destroy_notify(struct wl_listener *listener, void *UNUSED(data))
     if (seat->focused_view == view) {
         seat->focused_view = NULL;
     }
+    cursor_refresh_focus(server->input.cursor, NULL, NULL, NULL);
 
     struct kiwmi_view_child *child, *tmpchild;
     wl_list_for_each_safe (child, tmpchild, &view->children, link) {

--- a/kiwmi/input/seat.c
+++ b/kiwmi/input/seat.c
@@ -83,6 +83,7 @@ seat_focus_view(struct kiwmi_seat *seat, struct kiwmi_view *view)
     // move view to front
     wl_list_remove(&view->link);
     wl_list_insert(&desktop->views, &view->link);
+    cursor_refresh_focus(seat->input->cursor, NULL, NULL, NULL);
 
     seat->focused_view = view;
     view_set_activated(view, true);


### PR DESCRIPTION
Until now, focusing a different view didn't move pointer focus to it, even though it was under the cursor. The pointer had to move in order to switch its focus. Similar situations should be handled after this commit.

One possible downside is the focus being updated *too* often.

This PR also allows all layer shell to have pointer focus, but \[TODO\] I haven’t had a look at its consequences yet (e.g. the move/resize/show/hide rechecks are still only triggered from XDG shell).

I feel like any code I write today is low-quality, so I’ll understand it if you don’t want to merge this.