### PR TITLE
meson.build: check git exit status

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -36,9 +36,16 @@ else
     error('git is required to make the version string')
   endif
 
-  git_commit_hash = run_command([git.path(), 'describe', '--always', '--tags']).stdout().strip()
-  git_branch = run_command([git.path(), 'rev-parse', '--abbrev-ref', 'HEAD']).stdout().strip()
-  version = '"@0@ (" __DATE__ ", branch \'@1@\')"'.format(git_commit_hash, git_branch)
+  git_commit_hash = run_command([git.path(), 'describe', '--always', '--tags'], check: false)
+  git_branch = run_command([git.path(), 'rev-parse', '--abbrev-ref', 'HEAD'], check: false)
+  if git_commit_hash.returncode() != 0 or git_branch.returncode() != 0
+    error('need the git directory to make the version string')
+  endif
+
+  version = '"@0@ (" __DATE__ ", branch \'@1@\')"'.format(
+    git_commit_hash.stdout().strip(),
+    git_branch.stdout().strip(),
+  )
 endif
 add_project_arguments('-DKIWMI_VERSION=@0@'.format(version), language: 'c')
 


### PR DESCRIPTION
~~The default value for this argument will change in a future meson
release. This commit silences the warning and keeps the old behavior.~~

The default value for the `check` argument on `run_command` will soon
change from false to true. Set it explicitly to false in order to
silence the warning, and check the exit status ourselves for a nicer
error message.