### PR TITLE
Fix active output segfault when view is off screen

### DIFF
--- a/kiwmi/desktop/desktop.c
+++ b/kiwmi/desktop/desktop.c
@@ -112,7 +112,9 @@ desktop_active_output(struct kiwmi_server *server)
 
         struct wlr_output *wlr_output =
             wlr_output_layout_output_at(server->desktop.output_layout, lx, ly);
-        return wlr_output->data;
+        if (wlr_output) {
+            return wlr_output->data;
+        }
     }
 
     // 3. cursor


### PR DESCRIPTION
When a new view has just been created (i.e. we're running the
kiwmi:on( "view", ... callback ), that window can be in a weird
position, off all the existing outputs.  Because the code for getting
the active output asks for the output at that window's position, it can
get back NULL and then segfault when trying to return wlr_output->data.

Now, if there's no output at the window's position, the code just moves
on to look at the cursor.