### PR TITLE
input: map pointer to output if possible

### DIFF
--- a/include/input/input.h
+++ b/include/input/input.h
@@ -12,6 +12,7 @@
 
 struct kiwmi_input {
     struct wl_list keyboards; // struct kiwmi_keyboard::link
+    struct wl_list pointers;  // struct kiwmi_pointer::link
     struct wl_listener new_input;
     struct kiwmi_cursor *cursor;
     struct kiwmi_seat *seat;

--- a/include/input/pointer.h
+++ b/include/input/pointer.h
@@ -1,0 +1,27 @@
+/* Copyright (c), Niclas Meyer <niclas@countingsort.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef KIWMI_INPUT_POINTER_H
+#define KIWMI_INPUT_POINTER_H
+
+#include <wayland-server.h>
+#include <wlr/types/wlr_input_device.h>
+
+#include "server.h"
+
+struct kiwmi_pointer {
+    struct wlr_input_device *device;
+    struct wl_list link;
+
+    struct wl_listener device_destroy;
+};
+
+struct kiwmi_pointer *
+pointer_create(struct kiwmi_server *server, struct wlr_input_device *device);
+void pointer_destroy(struct kiwmi_pointer *pointer);
+
+#endif /* KIWMI_INPUT_POINTER_H */

--- a/kiwmi/desktop/output.c
+++ b/kiwmi/desktop/output.c
@@ -27,6 +27,7 @@
 #include "desktop/view.h"
 #include "input/cursor.h"
 #include "input/input.h"
+#include "input/pointer.h"
 #include "server.h"
 
 static void
@@ -355,8 +356,16 @@ new_output_notify(struct wl_listener *listener, void *data)
     wlr_output->data = output;
 
     struct kiwmi_cursor *cursor = server->input.cursor;
-
     wlr_xcursor_manager_load(cursor->xcursor_manager, wlr_output->scale);
+
+    struct kiwmi_pointer *pointer;
+    wl_list_for_each (pointer, &server->input.pointers, link) {
+        if (pointer->device->output_name
+            && strcmp(pointer->device->output_name, wlr_output->name) == 0) {
+            wlr_cursor_map_input_to_output(
+                cursor->cursor, pointer->device, wlr_output);
+        }
+    }
 
     wl_list_insert(&desktop->outputs, &output->link);
 

--- a/kiwmi/input/pointer.c
+++ b/kiwmi/input/pointer.c
@@ -1,0 +1,67 @@
+/* Copyright (c), Niclas Meyer <niclas@countingsort.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "input/pointer.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <wayland-server.h>
+#include <wlr/types/wlr_cursor.h>
+#include <wlr/types/wlr_input_device.h>
+
+#include "desktop/output.h"
+#include "input/cursor.h"
+#include "input/input.h"
+#include "server.h"
+
+static void
+pointer_destroy_notify(struct wl_listener *listener, void *UNUSED(data))
+{
+    struct kiwmi_pointer *pointer =
+        wl_container_of(listener, pointer, device_destroy);
+
+    pointer_destroy(pointer);
+}
+
+struct kiwmi_pointer *
+pointer_create(struct kiwmi_server *server, struct wlr_input_device *device)
+{
+    wlr_cursor_attach_input_device(server->input.cursor->cursor, device);
+
+    struct kiwmi_pointer *pointer = malloc(sizeof(*pointer));
+    if (!pointer) {
+        return NULL;
+    }
+
+    pointer->device = device;
+
+    pointer->device_destroy.notify = pointer_destroy_notify;
+    wl_signal_add(&device->events.destroy, &pointer->device_destroy);
+
+    if (device->output_name) {
+        struct kiwmi_output *output;
+        wl_list_for_each (output, &server->desktop.outputs, link) {
+            if (strcmp(device->output_name, output->wlr_output->name) == 0) {
+                wlr_cursor_map_input_to_output(
+                    server->input.cursor->cursor, device, output->wlr_output);
+                break;
+            }
+        }
+    }
+
+    return pointer;
+}
+
+void
+pointer_destroy(struct kiwmi_pointer *pointer)
+{
+    wl_list_remove(&pointer->device_destroy.link);
+    wl_list_remove(&pointer->link);
+
+    free(pointer);
+}

--- a/kiwmi/meson.build
+++ b/kiwmi/meson.build
@@ -10,6 +10,7 @@ kiwmi_sources = files(
   'input/cursor.c',
   'input/input.c',
   'input/keyboard.c',
+  'input/pointer.c',
   'input/seat.c',
   'luak/ipc.c',
   'luak/kiwmi_cursor.c',


### PR DESCRIPTION
This is needed in order for wlroots to interpret some values (mostly
coords of absolute input events) correctly. It for example fixes how the
pointer behaves with WLR_WL_OUTPUTS=2.

In order to also map the pointer/output pair when the pointer is created
before the output, a list of pointers has to be managed, which wasn't
needed until now.