### PR TITLE
output: wlr_renderer_begin with physical size

### DIFF
--- a/kiwmi/desktop/output.c
+++ b/kiwmi/desktop/output.c
@@ -194,11 +194,7 @@ output_frame_notify(struct wl_listener *listener, void *data)
     struct kiwmi_server *server   = wl_container_of(desktop, server, desktop);
     struct wlr_renderer *renderer = server->renderer;
 
-    int width;
-    int height;
-    wlr_output_effective_resolution(wlr_output, &width, &height);
-
-    wlr_renderer_begin(renderer, width, height);
+    wlr_renderer_begin(renderer, wlr_output->width, wlr_output->height);
     wlr_renderer_clear(renderer, desktop->bg_color);
 
     double output_lx = 0;


### PR DESCRIPTION
The rendered region size is independent on the output transform and
scale. Until now, an output with scale > 1 would render only its
(1 / scale) part; so with a scale of 2, only the top-left quarter (ie.
the left 1/2 of the top 1/2) would be visible.

Similarly, a portrait output (constructed as landscape, rotated by 90
degrees) would have an empty area at its bottom.

This bug was found while testing the output-management PR (#62).